### PR TITLE
[Bugfix] check data value is only useing 0x(upper case and number)

### DIFF
--- a/TestShell/shell_full_write.cpp
+++ b/TestShell/shell_full_write.cpp
@@ -40,6 +40,10 @@ bool ShellFullWrite::checkParameterValid(const std::string& cmd)
 		return false;
 	}
 
+	if (false == is_all_uppercase(value.substr(2, 8))){
+		return false;
+	}
+
 	if (false == is_valid_unsigned(value)) {
 		return false;
 	}
@@ -54,6 +58,16 @@ std::vector<std::string> ShellFullWrite::splitBySpace(const std::string& str) {
 		tokens.push_back(word);
 	}
 	return tokens;
+}
+
+bool ShellFullWrite::is_all_uppercase(const std::string& str) {
+
+	for (char ch : str) {
+		if ('A' <= ch && ch <= 'F') continue;
+		if ('0' <= ch && ch <= '9') continue;
+		return false;
+	}
+	return true;
 }
 
 bool ShellFullWrite::is_valid_unsigned(const std::string& str) {

--- a/TestShell/shell_full_write.h
+++ b/TestShell/shell_full_write.h
@@ -16,5 +16,6 @@ private:
 	IProcessExecutor* executor_;
 
 	std::vector<std::string> splitBySpace(const std::string& str);
+	bool is_all_uppercase(const std::string& str);
 	bool is_valid_unsigned(const std::string& str);
 };

--- a/TestShell/shell_write.cpp
+++ b/TestShell/shell_write.cpp
@@ -54,6 +54,10 @@ bool ShellWrite::checkParameterValid(const std::string& input)
         return false;
     }
 
+    if (false == is_all_uppercase(data.substr(2, 8))) {
+        return false;
+    }
+
     if (false == is_valid_unsigned(data)) {
         return false;
     }
@@ -83,6 +87,15 @@ bool ShellWrite::convertStoI(const std::string& str, int& val) {
     catch (const::std::out_of_range&) {
         return false;
     }
+}
+bool ShellWrite::is_all_uppercase(const std::string& str) {
+
+    for (char ch : str) {
+        if ('A' <= ch && ch <= 'F') continue;
+        if ('0' <= ch && ch <= '9') continue;
+        return false;
+    }
+    return true;
 }
 
 bool ShellWrite::is_valid_unsigned(const std::string& str) {

--- a/TestShell/shell_write.h
+++ b/TestShell/shell_write.h
@@ -22,6 +22,8 @@ private:
 
     bool convertStoI(const std::string& str, int& val);
 
+    bool is_all_uppercase(const std::string& str);
+
     bool is_valid_unsigned(const std::string& str);
 
     IProcessExecutor* executor_;


### PR DESCRIPTION
write path에서 data에 대한 정합성 체크를 강화합니다. 
0x다음 대문자와 숫자만 valid한 값으로 받을 수 있게 체크를 추가했습니다. 